### PR TITLE
Upload images and avatars to Firebase Cloud Storage

### DIFF
--- a/app/(modals)/post-modal.jsx
+++ b/app/(modals)/post-modal.jsx
@@ -9,6 +9,7 @@ import {
 } from "@/constants/ThemeVariables";
 import * as ImagePicker from "expo-image-picker";
 import * as Location from "expo-location";
+import { RootSiblingParent } from "react-native-root-siblings";
 import { Stack, router, useLocalSearchParams } from "expo-router";
 import { useEffect, useState } from "react";
 import {
@@ -25,6 +26,7 @@ import {
   View
 } from "react-native";
 import Toast from "react-native-root-toast";
+import { ERROR_TOAST_CONFIG } from "../../constants/toast-configurations";
 import { auth } from "../../firebase-config";
 import { getStorage, ref, uploadBytes, getDownloadURL } from "firebase/storage";
 import uuid from "react-native-uuid";
@@ -125,33 +127,46 @@ export default function PostModal() {
       Toast.show("Post successfully created");
       router.back();
     } else {
-      Toast.show("Sorry, something went wrong. Please try again.");
+      const data = await response.json();
+      const errorMessage = data?.error;
+      Toast.show(
+        "Sorry, something went wrong:\n" + (errorMessage || response.status),
+        ERROR_TOAST_CONFIG
+      );
     }
   }
 
   async function chooseImage() {
-    const result = await ImagePicker.launchImageLibraryAsync({
-      mediaTypes: ImagePicker.MediaTypeOptions.All,
-      allowsEditing: true,
-      quality: 0.3
-    });
+    try {
+      const result = await ImagePicker.launchImageLibraryAsync({
+        mediaTypes: ImagePicker.MediaTypeOptions.All,
+        allowsEditing: true,
+        quality: 0.3
+      });
 
-    if (!result.canceled) {
-      // Convert image to blob
-      const response = await fetch(result.assets[0].uri);
-      const blob = await response.blob();
+      if (!result.canceled) {
+        // Convert image to blob
+        const response = await fetch(result.assets[0].uri);
+        const blob = await response.blob();
 
-      // Create a reference to the file in Cloud Storage
-      const storage = getStorage();
-      const storageRef = ref(storage, `images/${uuid.v4()}`);
+        // Create a reference to the file in Cloud Storage
+        const storage = getStorage();
+        const storageRef = ref(storage, `images/${uuid.v4()}`);
 
-      // Upload the file to Cloud Storage
-      const snapshot = await uploadBytes(storageRef, blob);
+        // Upload the file to Cloud Storage
+        const snapshot = await uploadBytes(storageRef, blob);
 
-      // Get the download URL
-      const downloadURL = await getDownloadURL(snapshot.ref);
-      // Save the download URL to React state
-      setImage(downloadURL);
+        // Get the download URL
+        const downloadURL = await getDownloadURL(snapshot.ref);
+        // Save the download URL to React state
+        setImage(downloadURL);
+      }
+    } catch (error) {
+      console.error("Error choosing image:", error);
+      Toast.show(
+        "Sorry, something went wrong:\n" + error.message,
+        ERROR_TOAST_CONFIG
+      );
     }
   }
 
@@ -159,64 +174,71 @@ export default function PostModal() {
     <KeyboardAvoidingView
       behavior={Platform.OS === "ios" ? "padding" : "height"}
       style={styles.container}>
-      <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
-        <View style={styles.inner}>
-          <Stack.Screen
-            options={{
-              title: id ? "Update Post" : "Create Post",
-              headerLeft: () => (
-                <Button
-                  title="Cancel"
-                  color={Platform.OS === "ios" ? tintColorLight : tintColorDark}
-                  onPress={() => router.back()}
-                />
-              ),
-              headerRight: () => (
-                <Button
-                  title={id ? "Update" : "Create"}
-                  color={Platform.OS === "ios" ? tintColorLight : tintColorDark}
-                  onPress={handleSave}
-                />
-              )
-            }}
-          />
-
-          <Text style={styles.label}>Image</Text>
-          <TouchableOpacity onPress={chooseImage}>
-            <Image
-              style={styles.image}
-              source={{
-                uri:
-                  image ||
-                  "https://cederdorff.com/race/images/placeholder-image.webp"
+      {/* The Toast component must be a child of RootSiblingParent to be shown inside the modal */}
+      <RootSiblingParent>
+        <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+          <View style={styles.inner}>
+            <Stack.Screen
+              options={{
+                title: id ? "Update Post" : "Create Post",
+                headerLeft: () => (
+                  <Button
+                    title="Cancel"
+                    color={
+                      Platform.OS === "ios" ? tintColorLight : tintColorDark
+                    }
+                    onPress={() => router.back()}
+                  />
+                ),
+                headerRight: () => (
+                  <Button
+                    title={id ? "Update" : "Create"}
+                    color={
+                      Platform.OS === "ios" ? tintColorLight : tintColorDark
+                    }
+                    onPress={handleSave}
+                  />
+                )
               }}
             />
-          </TouchableOpacity>
-          <Text style={styles.label}>Caption</Text>
-          <TextInput
-            style={styles.input}
-            onChangeText={setCaption}
-            value={caption}
-            placeholder="Type your caption"
-          />
-          <Text style={styles.label}>City</Text>
-          <TextInput
-            style={styles.input}
-            placeholder="Type your city"
-            value={
-              location.city
-                ? `${location.city}, ${location.country}`
-                : "Loading your current location..."
-            }
-            editable={false}
-          />
-          <StyledButton
-            text={id ? "Update Post" : "Create Post"}
-            onPress={handleSave}
-            style="primary"
-          />
-        </View>
-      </TouchableWithoutFeedback>
+
+            <Text style={styles.label}>Image</Text>
+            <TouchableOpacity onPress={chooseImage}>
+              <Image
+                style={styles.image}
+                source={{
+                  uri:
+                    image ||
+                    "https://cederdorff.com/race/images/placeholder-image.webp"
+                }}
+              />
+            </TouchableOpacity>
+            <Text style={styles.label}>Caption</Text>
+            <TextInput
+              style={styles.input}
+              onChangeText={setCaption}
+              value={caption}
+              placeholder="Type your caption"
+            />
+            <Text style={styles.label}>City</Text>
+            <TextInput
+              style={styles.input}
+              placeholder="Type your city"
+              value={
+                location.city
+                  ? `${location.city}, ${location.country}`
+                  : "Loading your current location..."
+              }
+              editable={false}
+            />
+            <StyledButton
+              text={id ? "Update Post" : "Create Post"}
+              onPress={handleSave}
+              style="primary"
+            />
+          </View>
+        </TouchableWithoutFeedback>
+      </RootSiblingParent>
     </KeyboardAvoidingView>
   );
 }

--- a/constants/toast-configurations.js
+++ b/constants/toast-configurations.js
@@ -1,0 +1,8 @@
+import Toast from "react-native-root-toast";
+
+export const ERROR_TOAST_CONFIG = {
+  duration: Toast.durations.LONG,
+  position: Toast.positions.TOP,
+  backgroundColor: "#dc2626",
+  textColor: "white"
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "react-native-root-toast": "^3.5.1",
         "react-native-safe-area-context": "4.10.1",
         "react-native-screens": "3.31.1",
+        "react-native-uuid": "^2.0.2",
         "react-native-web": "~0.19.10",
         "react-native-webview": "^13.10.3"
       },
@@ -16951,6 +16952,15 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-uuid": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/react-native-uuid/-/react-native-uuid-2.0.2.tgz",
+      "integrity": "sha512-5ypj/hV58P+6VREdjkW0EudSibsH3WdqDERoHKnD9syFWjF+NfRWWrJb2sa3LIwI5zpzMvUiabs+DX40WHpEMw==",
+      "engines": {
+        "node": ">=10.0.0",
+        "npm": ">=6.0.0"
       }
     },
     "node_modules/react-native-web": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "react-native-root-toast": "^3.5.1",
     "react-native-safe-area-context": "4.10.1",
     "react-native-screens": "3.31.1",
+    "react-native-uuid": "^2.0.2",
     "react-native-web": "~0.19.10",
     "react-native-webview": "^13.10.3"
   },


### PR DESCRIPTION
Instead of saving base64-encoded strings to the db, this implements uploading of post images and user avatars to Firebase Cloud Storage and saves the public "download URL" to the db, so the images continue to function as before.

I've set up Cloud Storage on our account in "test mode" for now, so there are no access restrictions on images.

Things not currently implemented, but might be in a later PR:

- ~~Any kind of error handling (mostly because I couldn't get toast messages to appear above modals, so I gave up)~~(edit: implemented below)
- Deleting of images if the user changes avatar or deletes a post (would be nice to clean up)